### PR TITLE
logout method changed to POST

### DIFF
--- a/base/templates/base/task_list.html
+++ b/base/templates/base/task_list.html
@@ -8,8 +8,13 @@
     </div>
 
     {% if request.user.is_authenticated %}
-    <a href="{% url 'logout' %}">Logout</a> {% else %}
-    <a href="{% url 'login' %}">Login</a> {% endif %}
+    <form method="post" action="{% url 'logout' %}">
+        {% csrf_token %}
+        <button type="submit">logout</button>
+    </form>
+    {% else %}
+    <a href="{% url 'login' %}">Login</a> 
+    {% endif %}
 </div>
 
 


### PR DESCRIPTION
In recent updates of Django, the developers changed the LogoutView method from GET to POST. Since this tutorial has not the updated code, beginners may get confused why their `logout` button does not work properly.

Here is a related issue to look into: https://forum.djangoproject.com/t/deprecation-of-get-method-for-logoutview/25533